### PR TITLE
Explicitly allow targeting devices by filters

### DIFF
--- a/onesignalsdk/errors.py
+++ b/onesignalsdk/errors.py
@@ -1,0 +1,2 @@
+class OneSignalError(Exception):
+    pass


### PR DESCRIPTION
This change explicitly allows targeting devices for push notifications with filters and adds the documentation explaining that into the docstring.

**Notifications targeted by filters**

    one_signal.create_notification(
        contents='My push notification body',
        heading='My header',
        filters=[{'field': 'tag', 'key': 'mykey', 'relation': 'exists'}],
    )


**Notifications targeted by segments**

    one_signal.create_notification(
        contents='My push notification body',
        heading='My header',
        included_segments=['All'],
    )

**Notifications targeted by device/player IDs**

    one_signal.create_notification(
        contents='My push notification body',
        heading='My header',
        player_ids=['<DEVICE_ID1>'],
    )

If none of the 3 options for targeting are used, the API will now raise an exception:

    one_signal.create_notification()
    Traceback (most recent call last):
    ...
    onesignalsdk.errors.OneSignalError: Must send "player_ids", "included_segments" or "filters" to target devices

**NOTE:** This is a backward incompatible change in that if there were users relying on the default of sending to the "All" segment, that is no longer the default. After considering the possibilities here, I think the risk of accidentally sending a push notification to "All" is high and I don't think that's a very sane default.

- Fixes #3 
